### PR TITLE
Feat: Allow user-configurable directory for KUBECONFIG

### DIFF
--- a/kubectl-shell_ctx
+++ b/kubectl-shell_ctx
@@ -64,8 +64,12 @@ do_hook() {
 		KUBECONFIG=""
 	fi
 
+  if [ -z ${KUBECTL_SHELL_CTX_DIR+x} ]; then
+    KUBECTL_SHELL_CTX_DIR="/tmp"
+  fi
+
 	local ORIG_KUBECONFIG="$KUBECONFIG"
-	local TMP_KUBECONFIG=$(mktemp -q /tmp/kubectl-shell-ctx.XXXXXX || exit 1)
+	local TMP_KUBECONFIG=$(mktemp -q ${KUBECTL_SHELL_CTX_DIR}/kubectl-shell-ctx.XXXXXX || exit 1)
 
 	if [[ "$1" == "bash" ]] || [[ "$1" == "zsh" ]]; then
 		echo "export KUBECONFIG=$TMP_KUBECONFIG"
@@ -91,8 +95,12 @@ do_hook() {
 }
 
 do_clone() {
+  if [ -z ${KUBECTL_SHELL_CTX_DIR+x} ]; then
+    KUBECTL_SHELL_CTX_DIR="/tmp"
+  fi
+
 	# Find other shell-ctx instances
-	SHELL_CTXS=$(find /tmp/ -type f -name "kubectl-shell-ctx*" -not -name "$(basename $KUBECONFIG)" 2>/dev/null || true)
+	SHELL_CTXS=$(find ${KUBECTL_SHELL_CTX_DIR}/ -type f -name "kubectl-shell-ctx*" -not -name "$(basename $KUBECONFIG)" 2>/dev/null || true)
 	[[ -z "$SHELL_CTXS" ]] && err "no other shell-ctx instances found"
 	for SHELL_CTX in $SHELL_CTXS; do
 		local TMP_CTX_CONTEXT=$(KUBECONFIG=$SHELL_CTX $KUBECTL config current-context)

--- a/kubectl-shell_ctx
+++ b/kubectl-shell_ctx
@@ -64,9 +64,9 @@ do_hook() {
 		KUBECONFIG=""
 	fi
 
-  if [ -z ${KUBECTL_SHELL_CTX_DIR+x} ]; then
-    KUBECTL_SHELL_CTX_DIR="/tmp"
-  fi
+	if [ -z ${KUBECTL_SHELL_CTX_DIR+x} ]; then
+		KUBECTL_SHELL_CTX_DIR="/tmp"
+	fi
 
 	local ORIG_KUBECONFIG="$KUBECONFIG"
 	local TMP_KUBECONFIG=$(mktemp -q ${KUBECTL_SHELL_CTX_DIR}/kubectl-shell-ctx.XXXXXX || exit 1)
@@ -95,9 +95,9 @@ do_hook() {
 }
 
 do_clone() {
-  if [ -z ${KUBECTL_SHELL_CTX_DIR+x} ]; then
-    KUBECTL_SHELL_CTX_DIR="/tmp"
-  fi
+	if [ -z ${KUBECTL_SHELL_CTX_DIR+x} ]; then
+		KUBECTL_SHELL_CTX_DIR="/tmp"
+	fi
 
 	# Find other shell-ctx instances
 	SHELL_CTXS=$(find ${KUBECTL_SHELL_CTX_DIR}/ -type f -name "kubectl-shell-ctx*" -not -name "$(basename $KUBECONFIG)" 2>/dev/null || true)


### PR DESCRIPTION
### The Problem

On macOS, files in the `/tmp` directory are automatically deleted after three days. This caused the `$KUBECONFIG` file, which was stored there, to be unexpectedly removed, leading to a loss of user configuration.

### The Solution

Instead of hardcoding a path, this PR introduces the `$KUBECTL_SHELL_CTX_DIR` environment variable.

This allows users to specify a custom, persistent directory for storing the `$KUBECONFIG` file, giving them full control over its location and preventing it from being deleted by the OS.

**Usage:**
```sh
export KUBECTL_SHELL_CTX_DIR="$HOME/.tmp"
eval "$(kubectl-shell_ctx hook zsh)"
```